### PR TITLE
Fix multi chunk batch insert

### DIFF
--- a/src/core/query-compilable.ts
+++ b/src/core/query-compilable.ts
@@ -1,5 +1,5 @@
 import { QueryCompiled } from "./query-compiled";
 
 export interface QueryCompilable {
-    compile(): QueryCompiled;
+    compile(): QueryCompiled | QueryCompiled[];
 }

--- a/src/crud/commander-builder.ts
+++ b/src/crud/commander-builder.ts
@@ -58,18 +58,16 @@ export class CommanderBuilder {
     public batchInsert(tableName: string, columnsNames: string[], values: Array<ValueType[]>)
         : QueryCompiled[] {
         if (this.validValues(values)) {
-            return this.splitChunks(values, Math.floor(this._config.sqliteLimitVariables / columnsNames.length)).map(valuesChunk => {
-                return {
-                    params: [].concat(...valuesChunk),
-                    query: Utils.normalizeSqlString(
-                        `INSERT INTO ${tableName}
+            return this.splitChunks(values, Math.floor(this._config.sqliteLimitVariables / columnsNames.length)).map(valuesChunk => ({
+                params: [].concat(...valuesChunk),
+                query: Utils.normalizeSqlString(
+                    `INSERT INTO ${tableName}
                     (${columnsNames.join(", ")})
                     VALUES ${valuesChunk
-                            .map(a => `(${a.map(() => "?").join(", ")})`)
-                            .join(", ")}`
-                    ),
-                };
-            });
+                        .map(a => `(${a.map(() => "?").join(", ")})`)
+                        .join(", ")}`
+                )
+            }));
         }
     }
 

--- a/src/crud/crud-base-builder.ts
+++ b/src/crud/crud-base-builder.ts
@@ -10,7 +10,7 @@ import { CommanderBuilder } from "./commander-builder";
 export abstract class CrudBaseBuilder<
     T,
     TColumnsBuilder extends ColumnsValuesBuilder<T, TColumnsBuilder>
-    > extends SqlBaseBuilder<T> {
+> extends SqlBaseBuilder<T> {
 
     private _columnsCompiled: ColumnsCompiled = {
         columns: [],
@@ -30,12 +30,20 @@ export abstract class CrudBaseBuilder<
         this._commanderBuilder = new CommanderBuilder(config);
     }
 
-    public compile(): QueryCompiled {
+    public compile(): QueryCompiled | QueryCompiled[] {
         const compiledBase = this.buildBase();
+
+        if (Array.isArray(compiledBase))
+            return compiledBase.map(c => ({
+                query: `${c.query}${this.whereCompiled.where}`,
+                params: c.params.concat(this.whereCompiled.params)
+            }));
+
         return {
             params: compiledBase.params.concat(this.whereCompiled.params),
             query: `${compiledBase.query}${this.whereCompiled.where}`,
         };
+
     }
 
     protected getColumnsCompiled(): ColumnsCompiled {

--- a/src/crud/delete/delete.ts
+++ b/src/crud/delete/delete.ts
@@ -46,7 +46,7 @@ export class Delete<T> extends CrudBase<T, DeleteBuilder<T>, DeleteColumnsBuilde
 
     protected resolveDependencyByValue(dependency: MapperTable, value: ValueTypeToParse, index: number): QueryCompiled {
         const builder = new DeleteBuilder(void 0, void 0, dependency, this._builder.config);
-        return builder.compile();
+        return builder.compile() as QueryCompiled;
     }
 
     protected resolveDependency(dependency: MapperTable): QueryCompiled {
@@ -58,7 +58,7 @@ export class Delete<T> extends CrudBase<T, DeleteBuilder<T>, DeleteColumnsBuilde
                 }
                 where.equal(new ColumnRef(columnReference), KeyUtils.getKey(this.mapperTable, this.model()));
             });
-        return deleteBuilder.compile();
+        return deleteBuilder.compile() as QueryCompiled;
     }
 
     protected compileDependencyByValue(dependency: MapperTable): QueryCompiled[] {

--- a/src/crud/insert/insert-builder.ts
+++ b/src/crud/insert/insert-builder.ts
@@ -20,9 +20,9 @@ export class InsertBuilder<T> extends CrudBaseBuilder<T, InsertColumnsBuilder<T>
         return super.columnsBase(columnsCallback, this.columnsBuilder, this);
     }
 
-    protected buildBase(): QueryCompiled {
+    protected buildBase(): QueryCompiled[] {
         const columnsCompiled = this.getColumnsCompiled();
-        return this._commanderBuilder.batchInsert(this._tablename, columnsCompiled.columns, columnsCompiled.params)?.[0];
+        return this._commanderBuilder.batchInsert(this._tablename, columnsCompiled.columns, columnsCompiled.params);
     }
 
     public getModel(): T | Array<T> {

--- a/src/crud/sql-base-builder.ts
+++ b/src/crud/sql-base-builder.ts
@@ -12,7 +12,7 @@ export abstract class SqlBaseBuilder<T> implements QueryCompilable {
     protected whereCompiled: WhereCompiled = { where: "", params: [] };
 
     protected innerUsedAliasTest: Array<{ hasAlias: (alias: string) => boolean }> = [];
-
+    
     private readonly WHERE = " WHERE ";
     private NEXT_VALUE_ALIAS: number = 0;
 
@@ -50,9 +50,9 @@ export abstract class SqlBaseBuilder<T> implements QueryCompilable {
         return !!this.innerUsedAliasTest.find(x => x.hasAlias(alias));
     }
 
-    public abstract compile(): QueryCompiled;
+    public abstract compile(): QueryCompiled | QueryCompiled[];
 
-    protected abstract buildBase(): QueryCompiled;
+    protected abstract buildBase(): QueryCompiled | QueryCompiled[];
 
     protected compileWhere(current: WhereCompiled, compiled: WhereCompiled, addCommand: boolean = true) {
         if (compiled.where.length) {

--- a/src/crud/update/update.ts
+++ b/src/crud/update/update.ts
@@ -76,6 +76,6 @@ export class Update<T> extends CrudBase<T, UpdateBuilder<T>, UpdateColumnsBuilde
                 const columnReference = dependency.getColumnNameByField<DependencyListSimpleModel, any>(x => x.reference);
                 where.equal(new ColumnRef(columnReference), KeyUtils.getKey(this.mapperTable, this.model()));
             });
-        return deleteBuilder.compile();
+        return deleteBuilder.compile() as QueryCompiled;
     }
 }


### PR DESCRIPTION
Durante a inserção por batch, é verificado se o a quantidade de variáveis ultrapassa o limite definido na configuração `sqliteLimitVariables`.

Caso não ultrapassar, é inserido tudo em único comando de `insert`.

Caso contrário, a inserção é separada em `n` comandos de `insert`, conforme necessário. A implementação atual está somente executando o primeiro comando de `insert` desta listagem, ao invés de inserir todos, devido a está linha de código:
https://github.com/fernandocode/database-builder/blob/db8a7e2173f5a7ff08ed0d88116dbb56a551f772/src/crud/insert/insert-builder.ts#L25

Fiz as alterações necessárias para isto funcionar como esperado, mas gostaria de ver contigo antes como organizar melhor as alterações, caso você tenha algum input.